### PR TITLE
Use new tabbed form for auto active tab with first error field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 - Fix #167: added separator for concatenated search attributes
 - Enh #170: Confirmation before close a not saved task
 - Fix #169: Activate tab with first error field on edit a task
+- Enh #169: Use new tabbed form for auto active tab with first error field
 
 1.5.4  (April 28, 2021)
 -----------------------

--- a/models/forms/TaskForm.php
+++ b/models/forms/TaskForm.php
@@ -18,6 +18,7 @@ use humhub\modules\content\widgets\richtext\RichText;
 use humhub\modules\space\models\Space;
 use humhub\modules\tasks\helpers\TaskUrl;
 use humhub\modules\topic\models\Topic;
+use humhub\widgets\TabbedForm;
 use Yii;
 use yii\base\Model;
 use DateTime;
@@ -28,7 +29,7 @@ use humhub\modules\content\models\Content;
 use humhub\modules\tasks\models\Task;
 use yii\web\HttpException;
 
-class TaskForm extends Model
+class TaskForm extends Model implements TabbedForm
 {
 
     /**
@@ -483,17 +484,6 @@ class TaskForm extends Model
             'view' => 'edit-files',
             'linkOptions' => ['class' => 'tab-files'],
         ];
-
-        // Activate tab with first error field
-        if ($this->hasErrors()) {
-            $errorFields = array_keys($this->getErrors());
-            foreach ($tabs as $t => $tab) {
-                if (!empty(array_intersect($tab['fields'], $errorFields))) {
-                    $tabs[$t]['active'] = true;
-                    break;
-                }
-            }
-        }
 
         return $tabs;
     }

--- a/views/task/edit.php
+++ b/views/task/edit.php
@@ -26,7 +26,7 @@ Assets::register($this);
             <?= Tabs::widget([
                 'viewPath' => '@tasks/views/task',
                 'params' => ['form' => $form, 'taskForm' => $taskForm],
-                'items' => $taskForm->getTabs(),
+                'form' => $taskForm,
             ]); ?>
 
         </div>


### PR DESCRIPTION
Issue: https://github.com/humhub/tasks/pull/172#issuecomment-976209863
This PR can work only after merging the core `develop` PR https://github.com/humhub/humhub/pull/5472.