### PR TITLE
Update CreateTask.php

### DIFF
--- a/permissions/CreateTask.php
+++ b/permissions/CreateTask.php
@@ -39,6 +39,7 @@ class CreateTask extends BasePermission
      */
     protected $fixedGroups = [
         Space::USERGROUP_USER,
+        Space::USERGROUP_GUEST,
         User::USERGROUP_SELF,
         User::USERGROUP_FRIEND,
         User::USERGROUP_USER,


### PR DESCRIPTION
Guests should not be able to create a task. Moreover, it is not possible, as 'created_by' column cannot be null.