### PR TITLE
Fix using of Yii on view files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.8.2 (Unreleased)
 -------------------
 - Fix #232: Set All Icons color to @text-color-main (#555)
+- Fix #234: Fix using of Yii on view files
 
 1.8.1 (May 1, 2023)
 -------------------

--- a/widgets/views/taskInfoBox.php
+++ b/widgets/views/taskInfoBox.php
@@ -9,7 +9,6 @@
 
 $value = is_array($value) ? $value : [$value];
 
-use Yii;
 use humhub\libs\Html;
 use humhub\modules\ui\icon\widgets\Icon; ?>
 

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -8,7 +8,6 @@
 
 /* @var $task \humhub\modules\tasks\models\Task */
 
-use Yii;
 use humhub\modules\content\widgets\richtext\RichText;
 use humhub\modules\tasks\widgets\TaskRoleInfoBox;
 use humhub\modules\ui\icon\widgets\Icon;


### PR DESCRIPTION
Wall stream cannot be loaded because of errors:

`PHP Warning 'yii\\base\\ErrorException' with message 'The use statement with non-compound name 'Yii' has no effect' in /protected/modules/tasks/widgets/views/wallEntry.php:11`

`PHP Warning 'yii\\base\\ErrorException' with message 'The use statement with non-compound name 'Yii' has no effect' in /protected/modules/tasks/widgets/views/taskInfoBox.php:12`
    
