### PR TITLE
Add checklist in Wall Entry

### DIFF
--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -30,14 +30,14 @@ $hasItems = $task->hasItems()
     <?php endif; ?>
 
     <?php if(!empty($task->description) || $hasItems) : ?>
-        <div data-ui-markdown data-ui-show-more>
+        <div data-ui-show-more>
             <?php if(!empty($task->description)) : ?>
-                <div style="margin-bottom:10px">
+                <div data-ui-markdown style="margin-bottom:10px">
                     <?= RichText::output($task->description) ?>
                 </div>
             <?php endif; ?>
             <?php if($hasItems) : ?>
-                <div style="overflow-x:hidden">
+                <div class="task-details-body" style="overflow-x:hidden">
                     <?= TaskChecklist::widget(['task' => $task]) ?>
                 </div>
             <?php endif; ?>

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -13,6 +13,7 @@ use humhub\modules\tasks\widgets\TaskRoleInfoBox;
 use humhub\modules\ui\icon\widgets\Icon;
 use humhub\widgets\ModalButton;
 use humhub\modules\tasks\widgets\TaskPercentageBar;
+use humhub\modules\tasks\widgets\checklist\TaskChecklist;
 
 $color = Yii::$app->view->theme->variable('text-color-main');
 
@@ -27,9 +28,18 @@ $color = Yii::$app->view->theme->variable('text-color-main');
        <?= TaskPercentageBar::widget(['task' => $task, 'filterResult' => false]) ?>
     <?php endif; ?>
 
-    <?php if(!empty($task->description)) : ?>
-        <div data-ui-markdown data-ui-show-more style="margin-bottom:10px">
-            <?= RichText::output($task->description) ?>
+    <?php if(!empty($task->description) || $task->hasItems()) : ?>
+        <div data-ui-markdown data-ui-show-more>
+            <?php if(!empty($task->description)) : ?>
+                <div style="margin-bottom:10px">
+                    <?= RichText::output($task->description) ?>
+                </div>
+            <?php endif; ?>
+            <?php if($task->hasItems()) : ?>
+                <div style="overflow-x:hidden">
+                    <?= TaskChecklist::widget(['task' => $task]) ?>
+                </div>
+            <?php endif; ?>
         </div>
     <?php endif; ?>
 

--- a/widgets/views/wallEntry.php
+++ b/widgets/views/wallEntry.php
@@ -16,6 +16,7 @@ use humhub\modules\tasks\widgets\TaskPercentageBar;
 use humhub\modules\tasks\widgets\checklist\TaskChecklist;
 
 $color = Yii::$app->view->theme->variable('text-color-main');
+$hasItems = $task->hasItems()
 
 ?>
 <div class="wall-entry-task task">
@@ -28,14 +29,14 @@ $color = Yii::$app->view->theme->variable('text-color-main');
        <?= TaskPercentageBar::widget(['task' => $task, 'filterResult' => false]) ?>
     <?php endif; ?>
 
-    <?php if(!empty($task->description) || $task->hasItems()) : ?>
+    <?php if(!empty($task->description) || $hasItems) : ?>
         <div data-ui-markdown data-ui-show-more>
             <?php if(!empty($task->description)) : ?>
                 <div style="margin-bottom:10px">
                     <?= RichText::output($task->description) ?>
                 </div>
             <?php endif; ?>
-            <?php if($task->hasItems()) : ?>
+            <?php if($hasItems) : ?>
                 <div style="overflow-x:hidden">
                     <?= TaskChecklist::widget(['task' => $task]) ?>
                 </div>
@@ -43,7 +44,7 @@ $color = Yii::$app->view->theme->variable('text-color-main');
         </div>
     <?php endif; ?>
 
-    <div class="crearfix">
+    <div class="crearfix" style="margin-top:10px">
         <?= TaskRoleInfoBox::widget(['task' => $task, 'iconColor' => $color]) ?>
     </div>
 


### PR DESCRIPTION
Adds the task checklist to wall entries.

- Task description and checklist are wrapped in `<div ... "data-ui-show-more">`, so the wall entry doesn't get too long
- added margin-bottom: 10px to the TaskRoleInfoBox (to get more or less the same spacing for all elements)

Sometimes the checklist is more important than the description and contains important information. So it should be shown in the stream entry.

fixes https://github.com/humhub/tasks/issues/223